### PR TITLE
make it run with scala-3.0.0-RC1 except macroTypeclassDerivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 out/
 .DS_Store
+.idea

--- a/accessMembersByName/README.md
+++ b/accessMembersByName/README.md
@@ -5,7 +5,6 @@ We first access a single field in that manner. Then we call a method knowing onl
 The techniques used here are:
 
 - TASTy Reflect for typed AST tree manipulation
-- Unlifting a literal from an expression to a value
 - Learning which exactly trees to construct via `println(Term.of('{ ... }))` technique
 - Working with the TASTy Reflection API, learning how exactly to construct the TASTy nodes
 - Widening a TASTy type to prevent it from been to narrow

--- a/accessMembersByName/src/macro.scala
+++ b/accessMembersByName/src/macro.scala
@@ -16,9 +16,9 @@ inline def mcr(expr: Show[_], inline name: String): Any = ${ mcrImpl('expr, 'nam
 def mcrImpl(expr: Expr[Show[_]], nameExpr: Expr[String])(using Quotes): Expr[Any] =
   import quotes.reflect._
 
-  // Select field by name – use '{$expr.field}.unseal to see what tree needs to be created
-  val exprTree: Term = Term.of(expr)
-  val name: String = Unlifted.unapply(nameExpr).get
+  // Select field by name – use '{$expr.field}. to see what tree needs to be created
+  val exprTree: Term = expr.asTerm
+  val name: String = nameExpr.value.get
   val field: Term = Select.unique(exprTree, name)
 
   // Pass the result to a method call – same technique

--- a/build.sc
+++ b/build.sc
@@ -1,7 +1,7 @@
 import mill._, scalalib._
 
 trait DottyModule extends ScalaModule {
-  def scalaVersion = "3.0.0-M2"
+  def scalaVersion = "3.0.0-RC1"
 }
 
 object abstractTypeclassBody extends DottyModule

--- a/defaultParamsInference/src/macro.scala
+++ b/defaultParamsInference/src/macro.scala
@@ -16,7 +16,7 @@ def defaultParmasImpl[T](using quotes: Quotes, tpe: Type[T]): Expr[Map[String, A
 
   val body = comp.tree.asInstanceOf[ClassDef].body
   val idents: List[Ref] =
-    for case deff @ DefDef(name, _, _, _, tree) <- body
+    for case deff @ DefDef(name,_, _, _) <- body
     if name.startsWith("$lessinit$greater$default")
     yield Ref(deff.symbol)
   val identsExpr: Expr[List[Any]] =

--- a/macroTypeclassDerivation/src/Test.scala
+++ b/macroTypeclassDerivation/src/Test.scala
@@ -5,15 +5,15 @@ case class Person(name: String, address: String, age: Int) extends People
 case class Couple(person1: Person, person2: Person) extends People
 
 object Implicits extends LowPrioImplcits:
-  given Show[String]:
+  given Show[String] with
     def show(t: String) = t
 
-  given Show[Int]:
+  given Show[Int] with
     def show(t: Int) = t.toString
 end Implicits
 
 trait LowPrioImplcits:
-  inline given [T] as Show[T] = deriveShow[T]
+  inline given [T]:Show[T] = deriveShow[T]
 end LowPrioImplcits
 
 import Implicits.given


### PR DESCRIPTION
`macroTypeclassDerivation` does not work.

`inline given [T]:Show[T] = deriveShow[T]` could not be found by `Implicits.search` when search `Show[People]`. 